### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
     env:
       NODE_ENV: production
       CI: true
@@ -44,8 +47,19 @@ jobs:
 
       - run: bunx pkg-pr-new publish --bin --binaryApplication
 
+      # bun publish doesn't yet support npm's OIDC trusted publishing
+      # (https://github.com/oven-sh/bun/issues/24855), so the actual
+      # publish step uses the real npm CLI, which needs to be >=11.5.1.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Update npm
+        run: npm install -g npm@latest
+        if: ${{ steps.release.outputs.release_created }}
+
       - name: Publish to npm
-        run: bun publish --access public
-        env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
- The previous `bun publish --access public` step (authenticated via the `NPM_TOKEN` secret) was failing with a `404 Not Found` on the last release — npm masks granular-token permission mismatches as 404s, so this looked like the package didn't exist even though it does.
- `bun publish` doesn't support npm's OIDC trusted publishing yet ([oven-sh/bun#24855](https://github.com/oven-sh/bun/issues/24855)), so switched the actual publish step to the real npm CLI (trusted publishing requires npm ≥11.5.1).
- Added `permissions: id-token: write` to the job so GitHub can mint the OIDC token npm exchanges for a short-lived, workflow-scoped publish credential — no more long-lived `NPM_TOKEN` secret needed.

## Required manual step (not something I can do from here)
Before merging, configure the trusted publisher on **npmjs.com** for this package (Package → Settings → Publishing access → Trusted Publisher):
- Provider: **GitHub Actions**
- Organization/user: `WookieFPV`
- Repository: `bitrise-api-cli`
- Workflow filename: `release-please.yml`
- Environment: *(leave blank, none is used)*

Once that's set up, you can also delete the `NPM_TOKEN` repo secret since it's no longer used.

## Test plan
- [x] `bun run typecheck` / `bun run lint:CI` / `bun test` all pass (workflow-only change, no source touched)
- [x] Validated the workflow YAML parses correctly
- [ ] First real release after this merges will confirm the publish step succeeds end-to-end (can't be tested locally — needs the actual GitHub Actions OIDC token issuer)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8UdCGDMyaZPkrmAqjUJ1K)_