### PR TITLE
ci: add manual publish trigger for release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - "**"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Force the npm publish step to run (e.g. to retry a publish that failed after the release was already created)"
+        type: boolean
+        default: false
 
 jobs:
   release-please:
@@ -54,12 +60,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || inputs.publish }}
 
       - name: Update npm
         run: npm install -g npm@latest
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || inputs.publish }}
 
       - name: Publish to npm
         run: npm publish --access public
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || inputs.publish }}


### PR DESCRIPTION
## Summary
- `steps.release.outputs.release_created` only becomes `true` when release-please creates a brand-new release/tag in that specific run. A plain re-run after the publish step fails stays gated off forever, since the release already exists and there's nothing new for release-please to create.
- Adds a `workflow_dispatch` input (`publish`, boolean) that forces the build+publish steps to run regardless of that output, so a failed publish can be retried from the Actions UI ("Run workflow" → check "publish") without waiting for a new release.

## How to use it right now
Go to Actions → release-please → "Run workflow", check the `publish` input, and run it on `main`. It'll rebuild and re-attempt `npm publish` for whatever version is currently in `package.json`.

## Test plan
- [x] Validated workflow YAML parses correctly
- [x] `bun run typecheck` / `bun run lint:CI` / `bun test` all pass (workflow-only change, no source touched)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8UdCGDMyaZPkrmAqjUJ1K)_