### PR TITLE
fix: correct repository URL to match actual GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "module": "index",
   "type": "module",
   "bin": {
-    "bitrise-api-cli": "./dist/cli.js"
+    "bitrise-api-cli": "dist/cli.js"
   },
   "keywords": [
     "bitrise",
@@ -25,11 +25,11 @@
   "main": "dist/cli.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/WookieFPV/bitrise_api_cli.git"
+    "url": "git+https://github.com/WookieFPV/bitrise-api-cli.git"
   },
-  "homepage": "https://github.com/WookieFPV/bitrise_api_cli#readme",
+  "homepage": "https://github.com/WookieFPV/bitrise-api-cli#readme",
   "bugs": {
-    "url": "https://github.com/WookieFPV/bitrise_api_cli/issues"
+    "url": "https://github.com/WookieFPV/bitrise-api-cli/issues"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
The last publish attempt confirmed OIDC trusted publishing itself works — npm signed the provenance and logged it to Sigstore — but the final registry check rejected it:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/bitrise-api-cli
- Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "git+https://github.com/WookieFPV/bitrise_api_cli.git",
  expected to match "https://github.com/WookieFPV/bitrise-api-cli" from provenance
```

`package.json`'s `repository.url`, `homepage`, and `bugs.url` all pointed at `bitrise_api_cli` (underscores) instead of the actual repo `bitrise-api-cli` (hyphens). npm cross-checks `repository.url` against the GitHub Actions run's actual repo when verifying provenance, so the mismatch failed the publish at the very last step.

Fixed all three fields to the correct repo path. No other references to the old name exist elsewhere in the repo.

## Test plan
- [x] `bun run typecheck` / `bun run lint:CI` / `bun test` all pass
- [x] `npm pack` locally to confirm the tarball still builds correctly with the corrected fields

Once merged, re-run the release-please workflow with the `publish` input checked to retry the release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8UdCGDMyaZPkrmAqjUJ1K)_